### PR TITLE
Fix Tailwind CDN link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
 
     <!-- 1) Tailwind CSS from CDN -->
     <link
-      href="https://cdn.jsdelivr.net/npm/tailwindcss@4.1.8/dist/lib.min.js"
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@4.1.8/dist/tailwind.min.css"
       rel="stylesheet"
     />
 


### PR DESCRIPTION
## Summary
- point CDN link at the correct Tailwind CSS file

## Testing
- `npm install --quiet`
- `CI=true npm test --silent` *(fails: Unable to find an element with the text: /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_684f266a4754832a9d3a204b24a1c7d5