### PR TITLE
Improve chat UI theme and features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-scripts": "5.0.1",
+        "react-simple-typewriter": "^5.0.1",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -14643,6 +14644,19 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/react-simple-typewriter": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-simple-typewriter/-/react-simple-typewriter-5.0.1.tgz",
+      "integrity": "sha512-vA5HkABwJKL/DJ4RshSlY/igdr+FiVY4MLsSQYJX6FZG/f1/VwN4y1i3mPXRyfaswrvI8xii1kOVe1dYtO2Row==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
+    "react-simple-typewriter": "^5.0.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,12 @@
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
+    <!-- Brand font -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+
     <!-- 1) Tailwind CSS from CDN -->
 
     <link

--- a/src/index.css
+++ b/src/index.css
@@ -12,3 +12,30 @@
 .animate-fade-in {
   animation: fade-in 0.4s ease forwards;
 }
+
+@keyframes blink {
+  0%, 50% { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
+}
+
+.blinking-cursor::after {
+  content: '|';
+  display: inline-block;
+  margin-left: 2px;
+  animation: blink 1s steps(2, start) infinite;
+}
+
+:root {
+  --brand-primary: #4f46e5;
+  --brand-secondary: #9333ea;
+  --bg-gradient: linear-gradient(to bottom right, #f8fafc, #e0e7ff);
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+}
+
+body.dark {
+  background-color: #1f2937;
+  color: #f3f4f6;
+}


### PR DESCRIPTION
## Summary
- add Inter font link
- create brand color variables, dark mode support and cursor blink animation
- persist dark/light mode and add toggle
- apply gradient background and welcome screen fade
- enable conversation rename/delete actions with icons
- show typing cursor for assistant replies
- update tests

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853d48cc054832ab8a2cd4b07dd9940