### PR TITLE
Fix dark mode selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
 The page will reload when you make changes.\
 You may also see any lint errors in the console.
 
+### Dark Mode
+
+Click the sun/moon icon in the app header to toggle dark mode. The
+`html` element receives a `dark` class to activate Tailwind's dark
+styles, and fallback styles are defined for `html.dark` in
+`src/index.css`.
+
 ### `npm test`
 
 Launches the test runner in the interactive watch mode.\

--- a/src/index.css
+++ b/src/index.css
@@ -35,7 +35,7 @@ body {
   font-family: 'Inter', sans-serif;
 }
 
-body.dark {
+html.dark {
   background-color: #1f2937;
   color: #f3f4f6;
 }


### PR DESCRIPTION
## Summary
- update selector to `html.dark`
- document how to toggle dark mode

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853e017820c832abe7bc61174c0ff80