### PR TITLE
Fix selected mode sync and test

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,48 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import App from './App';
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = jest.fn();
+});
 
 test('renders QaAI landing screen with tagline "Democratising Expertise"', () => {
   render(<App />);
   const tagline = screen.getByTestId('tagline');
   expect(tagline).toBeInTheDocument();
+});
+
+test('opening a conversation updates the mode badge', async () => {
+  const conversations = [
+    {
+      id: 1,
+      title: 'Finance chat',
+      messages: [
+        { id: 1, type: 'user', content: 'Hello', timestamp: '10:00' }
+      ],
+      mode: 'finance',
+      time: '10:00'
+    },
+    {
+      id: 2,
+      title: 'Legal chat',
+      messages: [
+        { id: 2, type: 'assistant', content: 'Hi', timestamp: '11:00' }
+      ],
+      mode: 'legal',
+      time: '11:00'
+    }
+  ];
+
+  localStorage.setItem('conversations', JSON.stringify(conversations));
+
+  render(<App />);
+
+  fireEvent.click(screen.getByText('Legal chat'));
+
+  const badges = await screen.findAllByText(/Legal Mode/i);
+  expect(badges.length).toBeGreaterThan(0);
 });

--- a/src/QaAIUI.jsx
+++ b/src/QaAIUI.jsx
@@ -241,6 +241,7 @@ const QaAIUI = () => {
     if (!conv) return;
     setCurrentConversationId(id);
     setMessages(conv.messages || []);
+    setSelectedMode(conv.mode || null);
   };
 
   return (


### PR DESCRIPTION
## Summary
- sync selected mode when opening a conversation
- test that opening a saved conversation restores its mode

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853e021029c832ab1ad1d60219afc63