### PR TITLE
Add env key config and legal mode instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ Click the sun/moon icon in the app header to toggle dark mode. The
 styles, and fallback styles are defined for `html.dark` in
 `src/index.css`.
 
+### API Key Configuration
+
+The application expects an OpenAI API key to make requests. Create a `.env.local` file in the project root and add:
+
+```
+REACT_APP_OPENAI_API_KEY=your-openai-key
+```
+
+Restart the development server after editing the file.
+
 ### `npm test`
 
 Launches the test runner in the interactive watch mode.\


### PR DESCRIPTION
## Summary
- load OpenAI API key from `REACT_APP_OPENAI_API_KEY`
- add detailed legal assistant instructions
- document API key configuration in README

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6854159a68a4832ab6028a5752e1e41d