### PR TITLE
Add runtime API key prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,19 @@ styles, and fallback styles are defined for `html.dark` in
 
 ### API Key Configuration
 
-The application expects an OpenAI API key to make requests. Copy `.env.example` to
-`.env.local` and then set your key:
+The application needs an OpenAI API key to make requests. You can either provide
+it via an environment variable or enter it each time the app starts.
+
+To store it in an environment file, copy `.env.example` to `.env.local` and set
+`REACT_APP_OPENAI_API_KEY`:
 
 ```bash
 cp .env.example .env.local
 ```
 
-Edit `.env.local` and replace the placeholder value for
-`REACT_APP_OPENAI_API_KEY`. Restart the development server after editing the
-file.
+Edit `.env.local` and replace the placeholder value for `REACT_APP_OPENAI_API_KEY`.
+Restart the development server after editing the file. If the environment
+variable is not set, the app will prompt you to supply the key on first load.
 
 ### `npm test`
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -5,6 +5,10 @@ afterEach(() => {
   localStorage.clear();
 });
 
+beforeEach(() => {
+  process.env.REACT_APP_OPENAI_API_KEY = 'test';
+});
+
 beforeAll(() => {
   Element.prototype.scrollIntoView = jest.fn();
 });

--- a/src/QaAIUI.jsx
+++ b/src/QaAIUI.jsx
@@ -70,15 +70,17 @@ const QaAIUI = () => {
     return saved ? JSON.parse(saved) : false;
   });
   const apiKey = process.env.REACT_APP_OPENAI_API_KEY || '';
+  const [userApiKey, setUserApiKey] = useState('');
+  const [tempApiKey, setTempApiKey] = useState('');
   const messagesEndRef = useRef(null);
 
   useEffect(() => {
-    if (!apiKey) {
+    if (!apiKey && !userApiKey) {
       console.error(
-        'OpenAI API key is missing. Set REACT_APP_OPENAI_API_KEY in your environment.'
+        'OpenAI API key is missing. Provide it via REACT_APP_OPENAI_API_KEY or enter it at runtime.'
       );
     }
-  }, [apiKey]);
+  }, [apiKey, userApiKey]);
 
   const [conversations, setConversations] = useState(() => {
     const saved = localStorage.getItem('conversations');
@@ -123,6 +125,30 @@ const QaAIUI = () => {
     medical: { main: 'bg-red-50 dark:bg-gray-900', sidebar: 'bg-red-100 dark:bg-gray-800' },
     agent: { main: 'bg-purple-50 dark:bg-gray-900', sidebar: 'bg-purple-100 dark:bg-gray-800' }
   };
+
+  if (!apiKey && !userApiKey) {
+    return (
+      <div className="flex items-center justify-center h-screen bg-gray-100 dark:bg-gray-900">
+        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md w-80">
+          <h2 className="text-lg font-medium mb-4 text-gray-900 dark:text-gray-100">Enter OpenAI API Key</h2>
+          <input
+            type="password"
+            className="w-full border border-gray-300 dark:border-gray-700 rounded p-2 mb-4 dark:bg-gray-700 dark:text-gray-100"
+            value={tempApiKey}
+            onChange={(e) => setTempApiKey(e.target.value)}
+            placeholder="sk-..."
+          />
+          <button
+            onClick={() => setUserApiKey(tempApiKey.trim())}
+            disabled={!tempApiKey.trim()}
+            className="w-full bg-gray-900 text-white py-2 rounded disabled:opacity-50"
+          >
+            Continue
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -169,11 +195,12 @@ const QaAIUI = () => {
         mode: selectedMode,
         userMessage
       });
+      const keyToUse = userApiKey || apiKey;
       const response = await fetch('https://api.openai.com/v1/chat/completions', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`
+          Authorization: `Bearer ${keyToUse}`
         },
         body: JSON.stringify({
           model: 'gpt-4o-2024-08-06',
@@ -252,6 +279,7 @@ const QaAIUI = () => {
 
   const handleSendMessage = async () => {
     if (!inputValue.trim() || isGenerating) return;
+    if (!apiKey && !userApiKey) return;
     const timestamp = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
     const newMessage = { id: Date.now(), type: 'user', content: inputValue.trim(), timestamp };
     setMessages(prev => [...prev, newMessage]);


### PR DESCRIPTION
## Summary
- allow users to supply their OpenAI API key at runtime via a small form
- check for runtime or env API key before sending requests
- update README instructions for new behaviour
- adjust tests to set API key through environment variable

## Testing
- `npm test --silent --yes`

------
https://chatgpt.com/codex/tasks/task_e_685440eb3e68832aa3c67ef9198adaea