### PR TITLE
Add mode gradient support

### DIFF
--- a/src/QaAIUI.jsx
+++ b/src/QaAIUI.jsx
@@ -105,6 +105,15 @@ const QaAIUI = () => {
   }, [isDarkMode]);
 
   useEffect(() => {
+    const root = document.documentElement;
+    if (selectedMode) {
+      root.dataset.mode = selectedMode;
+    } else {
+      delete root.dataset.mode;
+    }
+  }, [selectedMode]);
+
+  useEffect(() => {
     const first = conversations[0];
     if (first && currentConversationId === null) {
       setCurrentConversationId(first.id);

--- a/src/index.css
+++ b/src/index.css
@@ -35,6 +35,22 @@
   --bg-gradient: linear-gradient(to bottom right, #f8fafc, #e0e7ff);
 }
 
+html[data-mode='legal'] {
+  --bg-gradient: linear-gradient(to bottom right, #f0fdf4, #dcfce7);
+}
+
+html[data-mode='finance'] {
+  --bg-gradient: linear-gradient(to bottom right, #eff6ff, #dbeafe);
+}
+
+html[data-mode='medical'] {
+  --bg-gradient: linear-gradient(to bottom right, #fef2f2, #fee2e2);
+}
+
+html[data-mode='agent'] {
+  --bg-gradient: linear-gradient(to bottom right, #faf5ff, #ede9fe);
+}
+
 body {
   font-family: "Syne", Inter, -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", system-ui, sans-serif;
 }
@@ -42,4 +58,5 @@ body {
 html.dark {
   background-color: #1f2937;
   color: #f3f4f6;
+  --bg-gradient: linear-gradient(to bottom right, #1f2937, #111827);
 }


### PR DESCRIPTION
## Summary
- support per-mode gradients via CSS custom properties
- set/remove document `data-mode` when selectedMode changes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685809ad21e8832abdf0e0d56946c82f