### PR TITLE
Set Inter as default font

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,10 +18,6 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
       rel="stylesheet"
     />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Syne:wght@400;700&display=swap"
-      rel="stylesheet"
-    />
 
     <!-- App title -->
     <title>QaAI</title>

--- a/src/QaAIUI.jsx
+++ b/src/QaAIUI.jsx
@@ -53,20 +53,20 @@ const renderAssistantContent = (content) => {
     if (trimmed === "") return <br key={idx} />;
     if (/^\d+\.\s/.test(trimmed)) {
       return (
-        <div key={idx} className="mb-1 font-syrene">
+        <div key={idx} className="mb-1 font-sans">
           {trimmed}
         </div>
       );
     }
     if (trimmed.startsWith("- Reasoning:")) {
       return (
-        <div key={idx} className="ml-4 text-sm text-gray-500 font-syrene">
+        <div key={idx} className="ml-4 text-sm text-gray-500 font-sans">
           {trimmed}
         </div>
       );
     }
     return (
-      <div key={idx} className="font-syrene">
+      <div key={idx} className="font-sans">
         {trimmed}
       </div>
     );
@@ -541,12 +541,12 @@ const QaAIUI = () => {
           {messages.length === 0 ? (
             <div className="flex flex-col items-center justify-center px-4 py-8 max-w-2xl mx-auto min-h-full animate-fade-in">
               <h1
-                className="text-3xl font-normal text-gray-900 mb-8 font-syrene"
+                className="text-3xl font-normal text-gray-900 mb-8 font-sans"
               >
                 Good afternoon, Oliver
               </h1>
               <p
-                className="font-syrene text-gray-600 dark:text-gray-300 text-lg mb-12"
+                className="font-sans text-gray-600 dark:text-gray-300 text-lg mb-12"
                 style={{
                   letterSpacing: "-0.02em",
                 }}
@@ -603,7 +603,7 @@ const QaAIUI = () => {
               </div>
               <p
                 data-testid="tagline"
-                className="font-syrene text-gray-500 text-sm mt-12"
+                className="font-sans text-gray-500 text-sm mt-12"
                 style={{
                   letterSpacing: "0.01em",
                 }}

--- a/src/index.css
+++ b/src/index.css
@@ -36,7 +36,7 @@
 }
 
 body {
-  font-family: "Syne", Inter, -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", system-ui, sans-serif;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
 }
 
 html.dark {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,8 +8,7 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        'inter': ['Inter', 'system-ui', 'sans-serif'],
-        'syrene': ['"Syne"', 'sans-serif'],
+        sans: ['Inter', 'ui-sans-serif', 'system-ui'],
       },
       animation: {
         'fade-in': 'fade-in 0.4s ease forwards',


### PR DESCRIPTION
## Summary
- configure Tailwind `fontFamily.sans` to use Inter
- drop Syne font and update stylesheet references
- remove `font-syrene` classes and use `font-sans`
- rebuild project

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685809cd9398832a8b8b0e5d7558ea99