### PR TITLE
Load Inter font via CSS import

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,11 +13,7 @@
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
-    <!-- Brand font -->
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
-      rel="stylesheet"
-    />
+    <!-- Brand font removed: now loaded via CSS import -->
 
     <!-- App title -->
     <title>QaAI</title>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Summary
- load Inter font via `@import` in `index.css`
- remove redundant Inter `<link>` tag from `index.html`

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68581688299c832a9c7b39e50f490f4e