### PR TITLE
Improve glass UI with panel frame and gradient

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,5 +2,9 @@ import React from 'react';
 import QaAIUI from './QaAIUI';
 
 export default function App() {
-  return <QaAIUI />;
+  return (
+    <div className="app-frame">
+      <QaAIUI />
+    </div>
+  );
 }

--- a/src/QaAIUI.jsx
+++ b/src/QaAIUI.jsx
@@ -48,19 +48,18 @@ Additional rules:
 - Be neutral and accurate in tone.`;
 
 
-const IdeaCard = ({ icon: Icon, title, subtitle, onClick }) => (
-  <button
-    onClick={onClick}
-    className="w-40 h-44 rounded-3xl bg-white/60 dark:bg-gray-700/60 backdrop-blur-md shadow ring-1 ring-black/5 p-4 flex flex-col justify-between text-left hover:bg-white/70 dark:hover:bg-gray-700 transition-colors"
-  >
-    <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-white dark:bg-gray-800 ring-1 ring-black/5">
-      <Icon strokeWidth={2} className="h-4 w-4 text-gray-800 dark:text-gray-200" />
+const IdeaCard = ({ icon: Icon, title, subtitle }) => (
+  <div className="w-56 h-64 p-6 rounded-3xl glass flex flex-col justify-between">
+    <span className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-900/90 text-white">
+      <Icon strokeWidth={1.6} className="h-5 w-5" />
     </span>
-    <div className="space-y-1">
-      <p className="text-sm font-medium leading-tight text-gray-800 dark:text-gray-100">{title}</p>
-      <p className="text-xs text-gray-500 dark:text-gray-400">{subtitle}</p>
+    <div>
+      <h3 className="text-base font-medium tracking-tight text-gray-900 dark:text-white">
+        {title}
+      </h3>
+      <p className="text-sm text-gray-500">{subtitle}</p>
     </div>
-  </button>
+  </div>
 );
 
 const renderAssistantContent = (content) => {
@@ -466,7 +465,7 @@ const QaAIUI = () => {
             animate={{ x: 0, opacity: 1 }}
             exit={{ x: -260, opacity: 0 }}
             transition={{ type: "spring", stiffness: 260, damping: 30 }}
-            className={`w-64 h-full ${themeColors[selectedMode || "null"].sidebar} border-r border-black/5 dark:border-white/10 overflow-y-auto glass`}
+            className={`w-64 h-full ${themeColors[selectedMode || "null"].sidebar} overflow-y-auto glass`}
           >
             <div className="p-4">
               <button
@@ -601,21 +600,14 @@ const QaAIUI = () => {
         {/* Messages area */}
         <div className="flex-1 overflow-y-auto">
           {messages.length === 0 ? (
-            <div className="flex flex-col items-center justify-center px-4 py-8 max-w-2xl mx-auto min-h-full animate-fade-in">
-              <h1
-                className="text-3xl font-normal text-gray-900 mb-8 font-sans"
-              >
+            <div className="flex flex-col items-center justify-center px-4 py-8 max-w-2xl mx-auto min-h-full space-y-6 animate-fade-in">
+              <h1 className="text-3xl font-semibold tracking-tight text-gray-900">
                 Good afternoon, Oliver
               </h1>
-              <p
-                className="font-sans text-gray-600 dark:text-gray-300 text-lg mb-12"
-                style={{
-                  letterSpacing: "-0.02em",
-                }}
-              >
+              <p className="text-lg text-gray-600 dark:text-gray-300">
                 How can I help you today?
               </p>
-              <div className="grid sm:grid-cols-3 gap-4 mb-8 w-full">
+              <div className="grid sm:grid-cols-3 gap-4 w-full">
                 {suggestions.map((s, idx) => (
                   <IdeaCard
                     key={idx}
@@ -627,38 +619,27 @@ const QaAIUI = () => {
                 ))}
               </div>
             <div className="w-full max-w-xl mb-6">
-                <div className="relative">
-                  <textarea
-                    ref={inputRef}
-                    value={inputValue}
-                    onChange={(e) => setInputValue(e.target.value)}
-                    onKeyPress={handleKeyPress}
-                    placeholder="Message QaAI"
-                    className="w-full px-4 py-3 pr-12 rounded-2xl border border-gray-300 focus:border-gray-400 focus:outline-none resize-none text-base bg-white dark:bg-gray-700 dark:text-gray-100"
-                    rows="1"
-                    style={{ minHeight: "52px" }}
-                    disabled={isGenerating}
-                  />
-                  <div className="absolute right-2 bottom-2 flex items-center gap-1">
-                    <button className="p-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors">
-                      <Paperclip className="w-5 h-5 text-gray-400" />
-                    </button>
-                    <button
-                      onClick={handleSendMessage}
-                      disabled={!inputValue.trim() || isGenerating}
-                      className={`glass p-1.5 transition-colors ${
-                        inputValue.trim() && !isGenerating
-                          ? "bg-gradient-to-br from-[var(--brand-primary)] to-[var(--brand-secondary)] text-white"
-                          : "bg-white/30 dark:bg-[#1f1f22]/30 text-gray-400"
-                      }`}
-                    >
-                      <ArrowUp
-                        className={`w-5 h-5 ${inputValue.trim() && !isGenerating ? "text-white" : "text-gray-400 dark:text-gray-300"}`}
-                      />
-                    </button>
-                  </div>
-                </div>
+              <div className="flex items-center glass rounded-2xl px-4 py-3">
+                <textarea
+                  ref={inputRef}
+                  value={inputValue}
+                  onChange={(e) => setInputValue(e.target.value)}
+                  onKeyPress={handleKeyPress}
+                  placeholder="Message QaAI"
+                  className="flex-1 glass bg-transparent resize-none placeholder:text-gray-400"
+                  rows="1"
+                  disabled={isGenerating}
+                />
+                <button
+                  onClick={handleSendMessage}
+                  disabled={!inputValue.trim() || isGenerating}
+                  className="ml-2 h-8 px-3 flex items-center justify-center rounded-full bg-gradient-to-tr from-rose-400 to-amber-400 text-white text-sm shadow hover:brightness-110 transition"
+                >
+                  Send
+                  <ArrowUp className="ml-1 w-4 h-4 stroke-[2.2]" />
+                </button>
               </div>
+            </div>
               <div className="flex gap-3 flex-wrap justify-center">
                 {modes.map((mode) => (
                   <button
@@ -688,7 +669,7 @@ const QaAIUI = () => {
           ) : (
             <div className="flex flex-col h-full">
               <div className="flex-1 overflow-y-auto">
-                <div className="max-w-3xl mx-auto px-4 py-6">
+                <div className="max-w-3xl mx-auto px-4 py-6 pb-24">
                   {selectedMode && (
                     <div className="text-center mb-6">
                       <div className="glass inline-flex items-center gap-2 px-3 py-1.5 rounded-full">
@@ -765,35 +746,24 @@ const QaAIUI = () => {
               {/* Input area at bottom */}
               <div className="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-4">
                 <div className="max-w-3xl mx-auto">
-                  <div className="relative">
+                  <div className="flex items-center glass rounded-2xl px-4 py-3">
                     <textarea
                       value={inputValue}
                       onChange={(e) => setInputValue(e.target.value)}
                       onKeyPress={handleKeyPress}
                       placeholder={`Reply to QaAI${selectedMode ? ` (${modes.find((m) => m.id === selectedMode)?.label} mode)` : ""}...`}
-                      className="w-full px-4 py-3 pr-24 rounded-2xl border border-gray-300 focus:border-gray-400 focus:outline-none resize-none text-base bg-white dark:bg-gray-700 dark:text-gray-100"
+                      className="flex-1 glass bg-transparent resize-none placeholder:text-gray-400"
                       rows="1"
-                      style={{ minHeight: "52px" }}
                       disabled={isGenerating}
                     />
-                    <div className="absolute right-2 bottom-2 flex items-center gap-1">
-                      <button className="p-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors">
-                        <Paperclip className="w-5 h-5 text-gray-400" />
-                      </button>
-                      <button
-                        onClick={handleSendMessage}
-                        disabled={!inputValue.trim() || isGenerating}
-                        className={`glass p-1.5 transition-colors ${
-                          inputValue.trim() && !isGenerating
-                            ? "bg-gradient-to-br from-[var(--brand-primary)] to-[var(--brand-secondary)] text-white"
-                            : "bg-white/30 dark:bg-[#1f1f22]/30 text-gray-400"
-                        }`}
-                      >
-                        <ArrowUp
-                          className={`w-5 h-5 ${inputValue.trim() && !isGenerating ? "text-white" : "text-gray-400 dark:text-gray-300"}`}
-                        />
-                      </button>
-                    </div>
+                    <button
+                      onClick={handleSendMessage}
+                      disabled={!inputValue.trim() || isGenerating}
+                      className="ml-2 h-8 px-3 flex items-center justify-center rounded-full bg-gradient-to-tr from-rose-400 to-amber-400 text-white text-sm shadow hover:brightness-110 transition"
+                    >
+                      Send
+                      <ArrowUp className="ml-1 w-4 h-4 stroke-[2.2]" />
+                    </button>
                   </div>
                   {selectedMode && (
                     <div className="mt-2 flex items-center justify-between text-xs text-gray-500">

--- a/src/index.css
+++ b/src/index.css
@@ -38,23 +38,43 @@
 }
 
 html[data-mode='legal'] {
-  --bg-gradient: radial-gradient(circle at top left, #f0fdf4, #dcfce7);
+  --bg-gradient: radial-gradient(
+    120% 140% at 80% 20%,
+    rgba(228, 255, 237, 0.9) 0%,
+    rgba(203, 252, 223, 0.7) 40%,
+    rgba(250, 255, 240, 0.55) 100%
+  );
 }
 
 html[data-mode='finance'] {
-  --bg-gradient: radial-gradient(circle at top left, #eff6ff, #dbeafe);
+  --bg-gradient: radial-gradient(
+    120% 140% at 80% 20%,
+    rgba(235, 244, 255, 0.9) 0%,
+    rgba(215, 236, 255, 0.7) 40%,
+    rgba(240, 248, 255, 0.55) 100%
+  );
 }
 
 html[data-mode='medical'] {
-  --bg-gradient: radial-gradient(circle at top left, #fef2f2, #fee2e2);
+  --bg-gradient: radial-gradient(
+    120% 140% at 80% 20%,
+    rgba(255, 235, 235, 0.9) 0%,
+    rgba(255, 218, 218, 0.7) 40%,
+    rgba(255, 245, 245, 0.55) 100%
+  );
 }
 
 html[data-mode='agent'] {
-  --bg-gradient: radial-gradient(circle at top left, #faf5ff, #ede9fe);
+  --bg-gradient: radial-gradient(
+    120% 140% at 80% 20%,
+    rgba(243, 235, 255, 0.9) 0%,
+    rgba(230, 220, 255, 0.7) 40%,
+    rgba(250, 240, 255, 0.55) 100%
+  );
 }
 
-body {
-  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+html {
+  font-family: 'Inter', ui-sans-serif, system-ui;
 }
 
 html.dark {
@@ -63,9 +83,23 @@ html.dark {
   --bg-gradient: radial-gradient(circle at top left, #1f2937, #111827);
 }
 
+html::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAFhElEQVR4nD3S6UsTfgCA8WdHWl8Tt3IehWasA8PNZlmag0jBoqUQoqVsCEp5UOmLiEitF1J4YCUtVmFFJUYqW1M78Ehs80jFItOcTCPKIjVLwxeJst+L4PcXPHzgkQwODora2loCAwPRarVoNBpaWlrw9vbGbrdz//59bDYbAQEBmEwm3rx5Q39/P2FhYeTn51NXV4fZbCYvL4/z588jV6lUzMzMcOLECaxWK3NzczidTtra2picnKSrq4uUlBQqKirIysqisbERj8fDs2fP+Pz5M8PDw6xbtw6Xy8WxY8cgPz9fJCcnC4VCIXQ6naisrBQymUzs379fLC8vC4VCIRQKhZBIJMJgMAilUinKy8tFZWWl2LNnj+jr6xOTk5PCYrGI0NBQIdmxY4dYtWoVjx49YmRkhJGREZqamoiIiGB+fh6j0YharcbLy4vExET8/PyIiopi586dJCUlsWnTJg4fPkxkZCS9vb1IgoODhdFopKSkhODgYJaWlggKCsLHx4eHDx8CYLPZCAkJITQ0lJaWFrq7u3G5XLx9+xaHw8HY2Bh5eXkEBgYira+vx2Aw8PfvXxYWFtiyZQsTExOUlpby8eNH/P39AaiurmZmZgaz2Ux0dDQGgwG73U5ERARWq5XY2Fhu3ryJfHh4mE+fPjE4OEhzczNLS0u8e/cOt9vNhQsXcLvdJCQk0Nrailwu58qVK7jdbs6cOUN4eDharZaJiQlsNhsqlQqpWq0mKioKj8fD6tWrefDgAWVlZajVauLj43G73UilUiwWC2fPnsXX15eAgADMZjPLy8vMzs6Sl5dHZGQkdXV1/8gSiYShoSF6enqYmprCYDCQlpbGysoKdrsdiUTCtWvX2L59+/+R2tpavL29UalU3Lhxg/Xr1+PxeJBrNBp0Oh0ul4u7d+/i7e1NeHg4p0+fRiKRcOnSJb59+4bT6SQzM5OAgABqamro6Ojg6dOnVFRU0N3dTWFhIQ6HA0lISIgoLS0lIyODuLg4jh8/TkpKCgcPHiQmJoYNGzag1+v5+fMnr169wt/fn5cvXzIzM0N3dzejo6PEx8fz48cPkpKS4OTJk+LAgQMiKChIfPjwQQDi9+/foqGhQbS1tYkjR46ItWvXCp1OJ2QymcjOzhZKpVKkp6eLQ4cOifLycjE9PS2SkpKEw+EQ8tnZWa5fv87Q0BDT09MUFBSQnJyMVCplbGyMzZs309zczMaNG7FYLFy+fJn09HTMZjMrKyvMz8+jVqvR6XQ0NjYit1gs5OTkYDKZMBqNeDwesrKycDqdmEwmOjo6qK+vR6PR0NDQwOLiIgqFgl27duHr68vAwAD9/f10dXURHh4OLpdLPH/+XPj4+IijR4+Kzs5O0dTUJEpKSkRvb6/QaDRCo9GIiooKMTU1JaKjo8Xy8rK4ePGikMvlorW1VfT09Ai32y1SU1OFvKuri4GBAX79+sXWrVu5ffs2s7OzFBcXc+vWLVQqFXNzc2RmZiKVSvny5QtTU1OEhYVx584d9Ho9drudmpqaf4tt27ZNlJWV0dHRQVpaGnq9HplMRnFxMUqlEplMxrlz5/Dz86O/v5+mpia+f/9OT08PBQUF9PX1IYQgNzeXxMREJAUFBSI1NRW9Xs/4+Dh+fn4UFhaiVCqpqqoiJyeH2NhYMjIySEtLY2Fhga9fvxIXF8fo6Ci7d+/m8ePHaDQaYmJikBYVFfHnzx9evHhBZ2cnKysrxMXFodPpyM7OZnR0lKCgIFQqFQkJCRQVFbFmzRpOnTpFamoq1dXVaLVaHA4H6enpyOfn53n9+jVGo5Gqqir27dvH1atX2bt3L7m5uXh5edHe3o5SqeTevXtMTk6iUChob29nfHwcq9XKkydPWFxc5P379/wH0eJDiN9DHOYAAAAASUVORK5CYII=');
+  pointer-events: none;
+  z-index: -1;
+}
+
+
 @layer utilities {
+  .app-frame {
+    @apply m-[20px] md:m-[28px] rounded-[32px] overflow-hidden shadow-[0_4px_36px_-6px_rgba(0,0,0,0.08)];
+  }
+
   .glass {
-    @apply backdrop-blur-md bg-white/70 dark:bg-[#1f1f22]/60 ring-1 ring-white/15 shadow-sm;
+    @apply backdrop-blur-md bg-white/55 dark:bg-gray-800/60 ring-1 ring-black/10 dark:ring-white/10 shadow-sm;
   }
 }
 


### PR DESCRIPTION
## Summary
- wrap QaAI UI in panel frame
- apply new dual-tone gradients and noise
- implement glass utility
- modernize idea cards and input bars
- tweak typography and spacing

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685846407088832a83ee46424bcd6b4c