### PR TITLE
Add confidence badge component

### DIFF
--- a/src/Badge.jsx
+++ b/src/Badge.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { CheckCircle, AlertTriangle, XCircle } from "lucide-react";
+
+const Badge = ({ score }) => {
+  if (typeof score !== "number") return null;
+
+  let Icon = CheckCircle;
+  let color = "bg-emerald-500";
+
+  if (score < 0.4) {
+    Icon = XCircle;
+    color = "bg-rose-500";
+  } else if (score < 0.7) {
+    Icon = AlertTriangle;
+    color = "bg-amber-400";
+  }
+
+  return (
+    <div
+      className={`absolute -top-2 -right-2 w-5 h-5 rounded-full text-white flex items-center justify-center ${color}`}
+    >
+      <Icon className="w-3 h-3" />
+    </div>
+  );
+};
+
+export default Badge;

--- a/src/QaAIUI.jsx
+++ b/src/QaAIUI.jsx
@@ -15,6 +15,7 @@ import {
   Sun,
   Moon,
 } from "lucide-react";
+import Badge from "./Badge";
 
 const legalInstructions = `You are a legal assistant AI built to help users clarify vague legal questions and provide structured, jurisdiction-specific answers. Your task is to:
 
@@ -795,7 +796,10 @@ const QaAIUI = () => {
                           </div>
                         </div>
                       ) : (
-                        <div>
+                        <div className="relative">
+                          {typeof message.confidence === "number" && (
+                            <Badge score={message.confidence} />
+                          )}
                           <div
                             className={`glass px-4 py-2.5 rounded-2xl text-gray-900 dark:text-gray-100 leading-relaxed ${isGenerating && index === messages.length - 1 ? "blinking-cursor" : ""}`}
                           >


### PR DESCRIPTION
## Summary
- create `Badge` component to display assistant confidence via lucide icons
- show badge on assistant messages when `confidence` field exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c61eb5cb4832ab1e942eca6c2c45b