### PR TITLE
Implement confidence badge and reasoning card UI

### DIFF
--- a/src/Badge.jsx
+++ b/src/Badge.jsx
@@ -1,27 +1,23 @@
 import React from "react";
-import { CheckCircle, AlertTriangle, XCircle } from "lucide-react";
+import { Check, AlertTriangle, HelpCircle } from "lucide-react";
 
-const Badge = ({ score }) => {
+export default function Badge({ score }) {
   if (typeof score !== "number") return null;
 
-  let Icon = CheckCircle;
-  let color = "bg-emerald-500";
-
-  if (score < 0.4) {
-    Icon = XCircle;
-    color = "bg-rose-500";
-  } else if (score < 0.7) {
-    Icon = AlertTriangle;
-    color = "bg-amber-400";
-  }
+  const lvl = score >= 0.75 ? "high" : score >= 0.4 ? "med" : "low";
+  const Icon = { high: Check, med: AlertTriangle, low: HelpCircle }[lvl];
+  const cls = {
+    high: "bg-emerald-500",
+    med: "bg-amber-400",
+    low: "bg-rose-500",
+  }[lvl];
 
   return (
     <div
-      className={`absolute -top-2 -right-2 w-5 h-5 rounded-full text-white flex items-center justify-center ${color}`}
+      className={`absolute -top-1 -right-1 h-5 w-5 rounded-full ring-2 ring-white shadow flex items-center justify-center ${cls}`}
+      title={`Model confidence ${(score * 100).toFixed(0)}%`}
     >
-      <Icon className="w-3 h-3" />
+      <Icon className="w-[10px] h-[10px]" strokeWidth={2} />
     </div>
   );
-};
-
-export default Badge;
+}

--- a/src/QaAIUI.jsx
+++ b/src/QaAIUI.jsx
@@ -761,14 +761,39 @@ const QaAIUI = () => {
                       </div>
                     </div>
                   )}
-                  {messages.map((message, index) => (
-                    <ChatBubble
-                      key={message.id}
-                      message={message}
-                      isGenerating={isGenerating}
-                      isLast={index === messages.length - 1}
-                    />
-                  ))}
+                  {(() => {
+                    const lastIdx = (() => {
+                      for (let i = messages.length - 1; i >= 0; i--) {
+                        if (messages[i].role !== "reasoning") return i;
+                      }
+                      return -1;
+                    })();
+                    return messages.map((message, index) => {
+                      if (message.role === "reasoning") return null;
+                      const reasoningText =
+                        messages[index - 1]?.role === "reasoning"
+                          ? messages[index - 1].text
+                          : null;
+                      return (
+                        <React.Fragment key={message.id}>
+                          <div className="relative">
+                            <ChatBubble
+                              message={message}
+                              isGenerating={isGenerating}
+                              isLast={index === lastIdx}
+                            />
+                            {message.role === "assistant" &&
+                              typeof message.confidence === "number" && (
+                                <Badge score={message.confidence} />
+                              )}
+                          </div>
+                          {message.role === "assistant" && reasoningText && (
+                            <ReasoningCard text={reasoningText} />
+                          )}
+                        </React.Fragment>
+                      );
+                    });
+                  })()}
                   <div ref={messagesEndRef} />
                 </div>
               </div>

--- a/src/ReasoningCard.jsx
+++ b/src/ReasoningCard.jsx
@@ -1,24 +1,18 @@
 import React, { useState } from "react";
-import { ChevronDown } from "lucide-react";
+import { Info } from "lucide-react";
 
 const ReasoningCard = ({ text }) => {
   const [open, setOpen] = useState(false);
   return (
-    <div
-      className="glass rounded-2xl p-3 mt-2 cursor-pointer"
-      onClick={() => setOpen((o) => !o)}
-    >
-      <div className="flex items-center justify-between">
-        <span className="text-sm font-medium">Reasoning</span>
-        <ChevronDown
-          className={`w-4 h-4 transition-transform ${open ? "rotate-180" : ""}`}
-        />
+    <div className="glass rounded-xl px-3 py-2 mt-2 text-sm select-none">
+      <div
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-2 cursor-pointer"
+      >
+        <Info className="w-4 h-4" />
+        <span>{open ? "Hide" : "Show"} reasoning</span>
       </div>
-      {open && (
-        <div className="mt-2 text-sm text-gray-700 dark:text-gray-200 whitespace-pre-wrap">
-          {text}
-        </div>
-      )}
+      {open && <p className="mt-2 leading-relaxed">{text}</p>}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- update Badge to show color-coded score indicator
- rework ReasoningCard with show/hide interaction
- render Badge and ReasoningCard around assistant messages

## Testing
- `npm test --silent --yes` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68612da578a0832a8493aa7b6352c014