### PR TITLE
Add mode tags in assistant bubbles

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -87,3 +87,30 @@ test('suggestions change when mode is selected', () => {
   fireEvent.click(screen.getByText('Legal'));
   expect(screen.getByText(/Contract dispute/i)).toBeInTheDocument();
 });
+
+test('assistant messages display mode tag', async () => {
+  const conversations = [
+    {
+      id: 1,
+      title: 'Legal chat',
+      messages: [
+        { id: 1, role: 'assistant', md: 'Hi', ts: '10:00', mode: 'legal' }
+      ],
+      mode: 'legal',
+      time: '10:00'
+    }
+  ];
+
+  localStorage.setItem('conversations', JSON.stringify(conversations));
+
+  render(<App />);
+
+  fireEvent.change(screen.getByPlaceholderText('sk-...'), {
+    target: { value: 'test-key' }
+  });
+  fireEvent.click(screen.getByText('Continue'));
+
+  fireEvent.click(screen.getByText('Legal chat'));
+
+  expect(screen.getAllByText('Legal').length).toBeGreaterThan(0);
+});

--- a/src/QaAIUI.jsx
+++ b/src/QaAIUI.jsx
@@ -26,6 +26,7 @@ import Badge from "./Badge";
  * @property {"assistant"} role
  * @property {string} md
  * @property {string} ts
+ * @property {string} [mode]
  * @property {number} [confidence]
 *
  * @typedef {Object} UserMsg
@@ -423,6 +424,7 @@ const QaAIUI = () => {
                 role: "assistant",
                 md: node.answer,
                 ts,
+                mode: selectedMode,
                 ...(typeof node.confidence === "number" && {
                   confidence: node.confidence,
                 }),
@@ -434,6 +436,7 @@ const QaAIUI = () => {
                 msgs[idx] = {
                   ...msgs[idx],
                   md: node.answer,
+                  mode: selectedMode,
                   ...(typeof node.confidence === "number" && {
                     confidence: node.confidence,
                   }),

--- a/src/components/ChatBubble.jsx
+++ b/src/components/ChatBubble.jsx
@@ -3,6 +3,20 @@ import { motion } from "framer-motion";
 import { User } from "lucide-react";
 import ReasoningCard from "../ReasoningCard";
 
+const modeColor = {
+  legal: "bg-emerald-300",
+  finance: "bg-sky-300",
+  medical: "bg-rose-300",
+  agent: "bg-violet-300",
+};
+
+const modeLabel = {
+  legal: "Legal",
+  finance: "Finance",
+  medical: "Medical",
+  agent: "Agent",
+};
+
 export const renderAssistantContent = (content) => {
   if (!content) return null;
   return content.split("\n").map((line, idx) => {
@@ -56,7 +70,7 @@ const ChatBubble = ({ message, isLast, isGenerating }) => {
           </div>
         </div>
       ) : (
-        <div>
+        <div className="relative">
           <div
             className={`glass px-4 py-2.5 rounded-2xl text-gray-900 dark:text-gray-100 leading-relaxed bg-gradient-to-br from-white/80 to-gray-50/70 ${
               isGenerating && isLast ? "blinking-cursor" : ""
@@ -75,6 +89,13 @@ const ChatBubble = ({ message, isLast, isGenerating }) => {
               )
             )}
           </div>
+          {message.mode && (
+            <span
+              className={`absolute top-0 right-0 text-[11px] px-2 py-[2px] rounded-full ${modeColor[message.mode]}`}
+            >
+              {modeLabel[message.mode]}
+            </span>
+          )}
           {message.ts && <div className="text-xs text-gray-500 mt-1">{message.ts}</div>}
         </div>
       )}


### PR DESCRIPTION
## Summary
- show a pastel-coloured mode label on each assistant ChatBubble
- persist `mode` on assistant messages
- document new property and add test

## Testing
- `npm test --silent -- -u`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686150a40bb8832a8e0d2772379c0aa7