### PR TITLE
Add typewriter hook for assistant replies

### DIFF
--- a/src/__tests__/useTypewriter.test.js
+++ b/src/__tests__/useTypewriter.test.js
@@ -1,0 +1,25 @@
+import { renderHook, act } from '@testing-library/react';
+import useTypewriter from '../hooks/useTypewriter';
+
+jest.useFakeTimers();
+
+test('reveals characters over time', () => {
+  const { result } = renderHook(() => useTypewriter('abc', 10));
+
+  expect(result.current).toBe('');
+
+  act(() => {
+    jest.advanceTimersByTime(100);
+  });
+  expect(result.current).toBe('a');
+
+  act(() => {
+    jest.advanceTimersByTime(100);
+  });
+  expect(result.current).toBe('ab');
+
+  act(() => {
+    jest.advanceTimersByTime(100);
+  });
+  expect(result.current).toBe('abc');
+});

--- a/src/components/ChatBubble.jsx
+++ b/src/components/ChatBubble.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import { User } from "lucide-react";
 import ReasoningCard from "../ReasoningCard";
+import useTypewriter from "../hooks/useTypewriter";
 
 const modeColor = {
   legal: "bg-emerald-300",
@@ -48,6 +49,8 @@ const ChatBubble = ({ message, isLast, isGenerating }) => {
   if (message.role === "reasoning") {
     return <ReasoningCard text={message.text} />;
   }
+  const showTyping = message.role === "assistant" && isGenerating && isLast;
+  const typedText = useTypewriter(showTyping ? message.md || "" : "");
   return (
     <motion.div
       initial={{ opacity: 0, y: 8 }}
@@ -76,18 +79,19 @@ const ChatBubble = ({ message, isLast, isGenerating }) => {
               isGenerating && isLast ? "blinking-cursor" : ""
             }`}
           >
-            {message.md ? (
-              renderAssistantContent(message.md)
-            ) : (
-              isGenerating &&
-              isLast && (
-                <div className="flex gap-1">
-                  <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: "0ms" }}></div>
-                  <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: "150ms" }}></div>
-                  <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: "300ms" }}></div>
-                </div>
-              )
-            )}
+            {showTyping
+              ? typedText
+                ? renderAssistantContent(typedText)
+                : (
+                    <div className="flex gap-1">
+                      <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: "0ms" }}></div>
+                      <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: "150ms" }}></div>
+                      <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: "300ms" }}></div>
+                    </div>
+                  )
+              : message.md
+              ? renderAssistantContent(message.md)
+              : null}
           </div>
           {message.mode && (
             <span

--- a/src/hooks/useTypewriter.js
+++ b/src/hooks/useTypewriter.js
@@ -1,0 +1,25 @@
+import { useState, useEffect } from "react";
+
+function useTypewriter(text, speed = 12) {
+  const [displayed, setDisplayed] = useState("");
+
+  useEffect(() => {
+    let index = 0;
+    setDisplayed("");
+    if (!text) return;
+
+    const interval = setInterval(() => {
+      index += 1;
+      setDisplayed(text.slice(0, index));
+      if (index >= text.length) {
+        clearInterval(interval);
+      }
+    }, 1000 / speed);
+
+    return () => clearInterval(interval);
+  }, [text, speed]);
+
+  return displayed;
+}
+
+export default useTypewriter;


### PR DESCRIPTION
## Summary
- implement `useTypewriter` hook with incremental text display
- integrate typewriter effect into `ChatBubble`
- show loader only while no text is displayed
- test the hook

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686155df1158832a910f7627e42e794d