### PR TITLE
Implement sidebar search, pin, hover preview

### DIFF
--- a/src/QaAIUI.jsx
+++ b/src/QaAIUI.jsx
@@ -89,6 +89,7 @@ const QaAIUI = () => {
   const [inputValue, setInputValue] = useState("");
   const [selectedMode, setSelectedMode] = useState(null);
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const [filter, setFilter] = useState("");
   const [isGenerating, setIsGenerating] = useState(false);
   const [isDarkMode, setIsDarkMode] = useState(() => {
     const saved = localStorage.getItem("darkMode");
@@ -563,6 +564,7 @@ const QaAIUI = () => {
         minute: "2-digit",
       }),
       mode: selectedMode,
+      pinned: false,
     };
     setConversations((prev) => [newConv, ...prev]);
     setCurrentConversationId(id);
@@ -590,6 +592,12 @@ const QaAIUI = () => {
         return arr;
       });
     }
+  };
+
+  const handleTogglePin = (id) => {
+    setConversations((prev) =>
+      prev.map((c) => (c.id === id ? { ...c, pinned: !c.pinned } : c)),
+    );
   };
 
   const openConversation = (id) => {
@@ -629,12 +637,23 @@ const QaAIUI = () => {
               <h3 className="text-xs font-medium text-gray-600 dark:text-gray-400">
                 Today
               </h3>
+              <input
+                onChange={(e) => setFilter(e.target.value)}
+                value={filter}
+                className="glass w-full mb-2 px-3 py-1.5 rounded-lg text-sm"
+                placeholder="Search…"
+              />
             </div>
             <ConversationList
-              conversations={conversations}
+              conversations={conversations
+                .filter((c) =>
+                  c.title.toLowerCase().includes(filter.toLowerCase()),
+                )
+                .sort((a, b) => Number(b.pinned) - Number(a.pinned))}
               onOpen={openConversation}
               onRename={handleRenameConversation}
               onDelete={handleDeleteConversation}
+              onTogglePin={handleTogglePin}
               modes={modes}
             />
           </motion.aside>

--- a/src/components/ConversationList.jsx
+++ b/src/components/ConversationList.jsx
@@ -1,13 +1,13 @@
 import React from "react";
-import { Edit3, Trash2 } from "lucide-react";
+import { Edit3, Trash2, Star, StarOff } from "lucide-react";
 
-const ConversationList = ({ conversations, onOpen, onRename, onDelete, modes }) => {
+const ConversationList = ({ conversations, onOpen, onRename, onDelete, onTogglePin, modes }) => {
   return (
     <div>
       {conversations.map((conv) => (
         <div
           key={conv.id}
-          className="px-4 py-2 hover:bg-gray-200 cursor-pointer transition-colors group"
+          className="relative px-4 py-2 hover:bg-gray-200 cursor-pointer transition-colors group"
         >
           <div
             className="flex items-center justify-between"
@@ -24,16 +24,21 @@ const ConversationList = ({ conversations, onOpen, onRename, onDelete, modes }) 
                   )}
                 {conv.title}
               </div>
-              {conv.messages && conv.messages.length > 0 && (
-                <div className="text-xs text-gray-500">
-                  {(conv.messages[conv.messages.length - 1].role === 'reasoning'
-                    ? conv.messages[conv.messages.length - 1].text
-                    : conv.messages[conv.messages.length - 1].md
-                  ).slice(0, 30)}
-                </div>
-              )}
             </div>
             <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100">
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onTogglePin(conv.id);
+                }}
+                className="p-1 hover:bg-gray-300 dark:hover:bg-gray-600 rounded"
+              >
+                {conv.pinned ? (
+                  <Star className="w-4 h-4 fill-yellow-400 stroke-yellow-400" />
+                ) : (
+                  <StarOff className="w-4 h-4" />
+                )}
+              </button>
               <button
                 onClick={(e) => {
                   e.stopPropagation();
@@ -57,6 +62,14 @@ const ConversationList = ({ conversations, onOpen, onRename, onDelete, modes }) 
           {conv.time && (
             <div className="text-xs text-gray-400 dark:text-gray-500 mt-1">
               {conv.time}
+            </div>
+          )}
+          {conv.messages && conv.messages.length > 0 && (
+            <div className="hidden group-hover:block absolute left-full ml-2 top-1/2 -translate-y-1/2 glass px-3 py-2 w-52 text-xs">
+              {(conv.messages[conv.messages.length - 1].role === 'reasoning'
+                ? conv.messages[conv.messages.length - 1].text
+                : conv.messages[conv.messages.length - 1].md
+              ).slice(0, 100)}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- add filter state and search input
- allow pinning conversations
- show pinned items at top
- show last message snippet as tooltip on hover

## Testing
- `npm test --silent`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686157927110832aa9ad5031f68e425c