### PR TITLE
Fix conditional hook usage in ChatBubble

### DIFF
--- a/src/components/ChatBubble.jsx
+++ b/src/components/ChatBubble.jsx
@@ -46,11 +46,12 @@ export const renderAssistantContent = (content) => {
 };
 
 const ChatBubble = ({ message, isLast, isGenerating }) => {
+  const showTyping = message.role === "assistant" && isGenerating && isLast;
+  const typedText = useTypewriter(showTyping ? message.md || "" : "");
+
   if (message.role === "reasoning") {
     return <ReasoningCard text={message.text} />;
   }
-  const showTyping = message.role === "assistant" && isGenerating && isLast;
-  const typedText = useTypewriter(showTyping ? message.md || "" : "");
   return (
     <motion.div
       initial={{ opacity: 0, y: 8 }}


### PR DESCRIPTION
## Summary
- move `useTypewriter` usage before the early return in `ChatBubble`

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6861a1d64e40832a96dba42b1bc0b0b8