### PR TITLE
Add setup examples and revise INITIAL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_OPENAI_API_KEY=your-openai-api-key

--- a/INITIAL.md
+++ b/INITIAL.md
@@ -1,0 +1,27 @@
+## FEATURE:
+This project aims to build a React + Tailwind single page app that serves as a chat interface for an AI assistant. Key features to implement:
+- Dynamic radial background gradients for each domain (legal, finance, medical, agent) with matching dark‑mode variants.
+- A collapsible sidebar listing conversations with search, rename, delete and pin options.
+- Mode buttons positioned under the chat input. Selecting a mode updates the theme and highlights the active badge.
+- Reusable `.glass` styling for buttons, cards and containers defined in `src/index.css`.
+- Chat interface streams responses from the OpenAI Chat API using model `gpt-4.1-2025-04-14`. Responses display typing animation, optional reasoning details and confidence badges.
+- Conversations and dark mode preference persisted in `localStorage`.
+- Startup prompt asking for an OpenAI API key (stored only in memory).
+
+## EXAMPLES:
+The `examples/` folder contains reference files:
+- `openai-response.json` – sample JSON object returned by the API.
+- `conversation.json` – example of a conversation object saved in `localStorage`.
+- `fetch-openai.js` – minimal script illustrating how to call the Chat API with streaming enabled.
+
+## DOCUMENTATION:
+- [React documentation](https://reactjs.org/)
+- [Tailwind CSS documentation](https://tailwindcss.com/)
+- [eventsource-parser](https://github.com/EventSource/eventsource-parser)
+- [OpenAI Chat API](https://platform.openai.com/docs/api-reference/chat)
+
+## OTHER CONSIDERATIONS:
+- Global styles (background gradients, `.glass` class and subtle overlay pattern) live in `src/index.css`.
+- Deployment is configured for GitHub Pages via the `homepage` field in `package.json`.
+- Automated tests use `@testing-library/react` and Jest (see `src/App.test.js` and `src/__tests__/useTypewriter.test.js`).
+- API interactions require network access to OpenAI.

--- a/examples/conversation.json
+++ b/examples/conversation.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": 1,
+    "title": "New chat",
+    "messages": [
+      { "id": 1, "role": "user", "md": "Hello", "ts": "10:00" }
+    ],
+    "mode": null,
+    "time": "10:00"
+  }
+]

--- a/examples/fetch-openai.js
+++ b/examples/fetch-openai.js
@@ -1,0 +1,23 @@
+const fetch = require('node-fetch');
+
+async function run() {
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.REACT_APP_OPENAI_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-4.1-2025-04-14',
+      messages: [{ role: 'user', content: 'Hello' }],
+      stream: true,
+      response_format: { type: 'json_object' },
+    }),
+  });
+
+  for await (const chunk of res.body) {
+    console.log(chunk.toString());
+  }
+}
+
+run().catch(console.error);

--- a/examples/openai-response.json
+++ b/examples/openai-response.json
@@ -1,0 +1,6 @@
+{
+  "answer": "<markdown answer here>",
+  "reasoning": "<explanation of the answer>",
+  "confidence": 0.92,
+  "buttons": []
+}


### PR DESCRIPTION
## Summary
- expand INITIAL.md with more detail about planned features
- add examples directory with sample OpenAI response and conversation data
- include minimal fetch script demonstrating Chat API usage
- provide `.env.example` placeholder for API key

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686abddb0294832a830ea8c8e838ad43